### PR TITLE
No method redefinitions

### DIFF
--- a/lib/gir_ffi-pretty_printer/class_pretty_printer.rb
+++ b/lib/gir_ffi-pretty_printer/class_pretty_printer.rb
@@ -70,13 +70,15 @@ module GirFFI
       arr = []
       @klass.methods(false).sort.each do |mname|
         meth = @klass.method mname
+        ruby = meth.to_ruby
 
-        if meth.arity == -1
+        if meth.arity == -1 && ruby =~ /setup_and_call/
           @klass.setup_method mname.to_s
           meth = @klass.method mname
+          ruby = meth.to_ruby
         end
 
-        arr << meth.to_ruby
+        arr << ruby
       end
       arr.join "\n"
     end

--- a/lib/gir_ffi-pretty_printer/pretty_printer.rb
+++ b/lib/gir_ffi-pretty_printer/pretty_printer.rb
@@ -14,7 +14,9 @@ module GirFFI
     end
 
     def pretty_print_function(modul, mname)
-      modul.setup_method mname.to_s if modul.send :respond_to_missing?, mname
+      if !modul.methods.include?(mname.to_sym)
+        modul.setup_method mname.to_s
+      end
 
       meth = modul.method mname
       meth.to_ruby

--- a/test/integration/expected_gobject.rb
+++ b/test/integration/expected_gobject.rb
@@ -3397,14 +3397,10 @@ module GObject
     GObject::Lib.g_type_free_instance(_v1)
   end
   def self.type_from_name(name)
-    _v1 = GirFFI::InPointer.from_utf8(name)
-    _v2 = GObject::Lib.g_type_from_name(_v1)
-    return _v2
+    Lib.g_type_from_name(name)
   end
-  def self.type_fundamental(type_id)
-    _v1 = type_id
-    _v2 = GObject::Lib.g_type_fundamental(_v1)
-    return _v2
+  def self.type_fundamental(gtype)
+    Lib.g_type_fundamental(gtype)
   end
   def self.type_fundamental_next
     _v1 = GObject::Lib.g_type_fundamental_next
@@ -3492,10 +3488,7 @@ module GObject
     return _v3
   end
   def self.type_name_from_instance(instance)
-    _v1 = GObject::TypeInstance.from(instance)
-    _v2 = GObject::Lib.g_type_name_from_instance(_v1)
-    _v3 = _v2.to_utf8
-    return _v3
+    type_name(type_from_instance(instance))
   end
   def self.type_next_base(leaf_type, root_type)
     _v1 = leaf_type


### PR DESCRIPTION
Avoid redefining module functions and class singleton methods. This silences several warnings about redefined methods.