### PR TITLE
Simplify escaping for avoiding string interpolation

### DIFF
--- a/test/gir_ffi-pretty_printer/class_pretty_printer_test.rb
+++ b/test/gir_ffi-pretty_printer/class_pretty_printer_test.rb
@@ -65,7 +65,7 @@ describe GirFFI::ClassPrettyPrinter do
           class ComplexAlias < SimpleClass
 
             def bar_with_qux
-              "#\{bar_without_qux\}-more"
+              "\#{bar_without_qux}-more"
             end
             alias_method 'bar', 'bar_with_qux'
             alias_method 'bar_without_qux', 'bar'


### PR DESCRIPTION
The existing escaping worked, but the escape of the closing brace was redundant, and escaping the octothorpe is more idiomatic.
