### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/gir_ffi-pretty_printer.gemspec
+++ b/gir_ffi-pretty_printer.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["Changelog.md", "README.md"]
 
-  spec.add_runtime_dependency "bindings", "~> 1.0"
-  spec.add_runtime_dependency "gir_ffi", "~> 0.17.0"
-  spec.add_runtime_dependency "indentation", "~> 0.1.1"
-  spec.add_runtime_dependency "mvz-live_ast", "~> 2.0"
+  spec.add_dependency "bindings", "~> 1.0"
+  spec.add_dependency "gir_ffi", "~> 0.17.0"
+  spec.add_dependency "indentation", "~> 0.1.1"
+  spec.add_dependency "mvz-live_ast", "~> 2.0"
 
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
