### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'test/integration/expected_glib.rb'
     - 'test/integration/expected_gobject.rb'
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/gir_ffi-pretty_printer.gemspec
+++ b/gir_ffi-pretty_printer.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |spec|
     taking method overrides and hand-added methods into account.
   DESC
   spec.homepage = "http://www.github.com/mvz/gir_ffi-pretty_printer"
+
   spec.license = "LGPL-2.1+"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/gir_ffi-pretty_printer"


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
