### PR TITLE
Bump rubocop dependency versions and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,10 +17,6 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
 
-# Put development dependencies in the gemspec so rubygems.org knows about them
-Gemspec/DevelopmentDependencies:
-  EnforcedStyle: gemspec
-
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,14 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :development do
+  gem "minitest", "~> 6.0"
+  gem "rake", "~> 13.0"
+  gem "rake-manifest", "~> 0.2.0"
+  gem "rubocop", "~> 1.76"
+  gem "rubocop-minitest", "~> 0.39.1"
+  gem "rubocop-packaging", "~> 0.6.0"
+  gem "rubocop-performance", "~> 1.25"
+  gem "simplecov", "~> 0.22.0"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :development do
   gem "minitest", "~> 6.0"
   gem "rake", "~> 13.0"
   gem "rake-manifest", "~> 0.2.0"
-  gem "rubocop", "~> 1.76"
+  gem "rubocop", "~> 1.85"
   gem "rubocop-minitest", "~> 0.39.1"
   gem "rubocop-packaging", "~> 0.6.0"
-  gem "rubocop-performance", "~> 1.25"
+  gem "rubocop-performance", "~> 1.26"
   gem "simplecov", "~> 0.22.0"
 end

--- a/gir_ffi-pretty_printer.gemspec
+++ b/gir_ffi-pretty_printer.gemspec
@@ -34,13 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gir_ffi", "~> 0.18.0"
   spec.add_dependency "indentation", "~> 0.1.1"
   spec.add_dependency "mvz-live_ast", "~> 2.0"
-
-  spec.add_development_dependency "minitest", "~> 6.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.76"
-  spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.25"
-  spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/test/gir_ffi-pretty_printer/class_pretty_printer_test.rb
+++ b/test/gir_ffi-pretty_printer/class_pretty_printer_test.rb
@@ -2,24 +2,26 @@
 
 require "test_helper"
 
-class SimpleClass
-  def bar
-    "hello"
-  end
-end
-
-class SimpleAlias < SimpleClass
-  alias foo bar
-end
-
-class ComplexAlias < SimpleClass
-  alias bar_without_qux bar
-
-  def bar_with_qux
-    "#{bar_without_qux}-more"
+module TestClasses
+  class SimpleClass
+    def bar
+      "hello"
+    end
   end
 
-  alias bar bar_with_qux
+  class SimpleAlias < SimpleClass
+    alias foo bar
+  end
+
+  class ComplexAlias < SimpleClass
+    alias bar_without_qux bar
+
+    def bar_with_qux
+      "#{bar_without_qux}-more"
+    end
+
+    alias bar bar_with_qux
+  end
 end
 
 describe GirFFI::ClassPrettyPrinter do
@@ -27,10 +29,10 @@ describe GirFFI::ClassPrettyPrinter do
 
   describe "#pretty_print" do
     describe "for a class with a simple method definition" do
-      let(:printed_class) { SimpleClass }
+      let(:printed_class) { TestClasses::SimpleClass }
       it "pretty-prints the class" do
         expected = <<~RUBY.chomp
-          class SimpleClass < Object
+          class TestClasses::SimpleClass < Object
 
             def bar
               "hello"
@@ -45,10 +47,10 @@ describe GirFFI::ClassPrettyPrinter do
     end
 
     describe "for a class with a simple aliased method" do
-      let(:printed_class) { SimpleAlias }
+      let(:printed_class) { TestClasses::SimpleAlias }
       it "pretty-prints the class" do
         expected = <<~RUBY.chomp
-          class SimpleAlias < SimpleClass
+          class TestClasses::SimpleAlias < TestClasses::SimpleClass
 
             alias_method 'foo', 'bar'
           end
@@ -61,10 +63,10 @@ describe GirFFI::ClassPrettyPrinter do
     end
 
     describe "for a class with an alias chain" do
-      let(:printed_class) { ComplexAlias }
+      let(:printed_class) { TestClasses::ComplexAlias }
       it "pretty-prints the class" do
         expected = <<~RUBY.chomp
-          class ComplexAlias < SimpleClass
+          class TestClasses::ComplexAlias < TestClasses::SimpleClass
 
             def bar_with_qux
               "\#{bar_without_qux}-more"


### PR DESCRIPTION
- **Move development dependencies from gemspec to Gemfile**
- **Bump minimum rubocop dependency versions**
- **Fix Style/OneClassPerFile offenses**
